### PR TITLE
allow all browsers with webrtc apis

### DIFF
--- a/src/components/UnsupportedBrowserWarning/UnsupportedBrowserWarning.tsx
+++ b/src/components/UnsupportedBrowserWarning/UnsupportedBrowserWarning.tsx
@@ -15,10 +15,19 @@ const useStyles = makeStyles({
   },
 });
 
+function isWebRTCSupported() {
+  return (
+    typeof navigator === 'object' &&
+    typeof navigator.mediaDevices === 'object' &&
+    typeof navigator.mediaDevices.getUserMedia === 'function' &&
+    typeof RTCPeerConnection === 'function'
+  );
+}
+
 export default function UnsupportedBrowserWarning({ children }: { children: React.ReactElement }) {
   const classes = useStyles();
 
-  if (!Video.isSupported) {
+  if (!isWebRTCSupported()) {
     return (
       <Container>
         <Grid container justifyContent="center" className={classes.container}>


### PR DESCRIPTION
Before this PR the app showed an error message on brave, even though it had all the required APIs to work correctly. 

Twilio SDK has a method `isSupported` that is supposed to return true for all the browsers they officially support. 

This PR makes the browser check less restrictive - instead of checking for the browser in a list of accepted, it does feature check only. There is a chance that the app can break on certain browsers now though. Seemed OK from my initial testing though. 

closes https://github.com/alwaysbegrowing/fokus/issues/9